### PR TITLE
Support for Ubuntu Noble (fixes #12)

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,6 +12,8 @@ platforms:
     image: debian:latest
   - name: ubuntu-jammy
     image: ubuntu:jammy
+  - name: ubuntu-noble
+    image: ubuntu:noble
 provisioner:
   config_options:
     defaults:

--- a/molecule/devel/molecule.yml
+++ b/molecule/devel/molecule.yml
@@ -12,6 +12,8 @@ platforms:
     image: debian:latest
   - name: ubuntu-jammy
     image: ubuntu:jammy
+  - name: ubuntu-noble
+    image: ubuntu:noble
 provisioner:
   config_options:
     defaults:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -25,8 +25,6 @@
       with_items:
         - amd64
         - i386
-      # Ubuntu Noble has phased out most 32-bit (i386) support.
-      when: lsb_release_code_name.stdout != 'noble'
     - name: Ensures Apt cache is up-to-date
       ansible.builtin.apt:
         update_cache: true

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,18 +2,6 @@
 - name: Ensures Wine repository is configured
   become: true
   block:
-    - name: Adds architecture dependencies
-      ansible.builtin.lineinfile:
-        create: true
-        dest: /var/lib/dpkg/arch
-        line: '{{ item }}'
-        mode: "0644"
-      with_items:
-        - amd64
-        - i386
-    - name: Ensures Apt cache is up-to-date
-      ansible.builtin.apt:
-        update_cache: true
     - name: Ensures lsb_release command is present
       ansible.builtin.package:
         name: lsb-release
@@ -28,6 +16,20 @@
       ansible.builtin.command: /usr/bin/lsb_release -si
       become: false
       register: lsb_release_dist_id
+    - name: Adds architecture dependencies
+      ansible.builtin.lineinfile:
+        create: true
+        dest: /var/lib/dpkg/arch
+        line: '{{ item }}'
+        mode: "0644"
+      with_items:
+        - amd64
+        - i386
+      # Ubuntu Noble has phased out most 32-bit (i386) support.
+      when: lsb_release_code_name.stdout != 'noble'
+    - name: Ensures Apt cache is up-to-date
+      ansible.builtin.apt:
+        update_cache: true
     - name: Ensures Wine repo is present
       ansible.builtin.template:
         dest: /etc/apt/sources.list.d/winehq.list
@@ -51,7 +53,8 @@
         dest: /etc/apt/sources.list.d/ubuntu.list
         mode: "0644"
         src: winehq.Ubuntu.list.j2
-      when: lsb_release_dist_id.stdout in ["Ubuntu"]
+      when:
+        - lsb_release_dist_id.stdout in ["Ubuntu"]
     - name: Ensures Wine's backports repo Apt signing key is present
       ansible.builtin.apt_key:
         id: BBB8BD3BBE6AD3419048EDC50795A9A788A59C82
@@ -59,6 +62,8 @@
         url:
           "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xbbb8bd3bbe6ad341\
           9048edc50795a9a788a59c82"
+      when:
+        - lsb_release_dist_id.stdout in ["Ubuntu"]
 - name: Ensures Wine is present
   become: true
   block:

--- a/templates/winehq.Ubuntu.list.j2
+++ b/templates/winehq.Ubuntu.list.j2
@@ -1,1 +1,3 @@
+{% if lsb_release_code_name.stdout != 'noble' %}
 deb [trusted=yes] http://ppa.launchpad.net/cybermax-dexter/sdl2-backport/ubuntu {{ lsb_release_code_name.stdout }} main
+{% endif %}


### PR DESCRIPTION
## Summary by Sourcery

Adds support for Ubuntu Noble by updating the Wine repository configuration and adding a new platform to the test matrix.

Enhancements:
- Refactor the task to add architecture dependencies and update apt cache before ensuring lsb_release command is present.
- Add condition to prevent adding the sdl2-backport for Ubuntu Noble

Tests:
- Add Ubuntu Noble to the test matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for a new Ubuntu-based platform option ("ubuntu-noble") alongside existing offerings.
- **Refactor**
  - Optimized task sequencing for Wine repository configuration.
  - Enhanced conditional logic to adjust repository inclusion based on system release details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->