### PR TITLE
Standardize privilege escalation with 'become_method: ansible.builtin.su' in Winetricks tasks

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -7,13 +7,13 @@ on:
     paths-ignore:
       - '**/*.cfg'
       - '**/*.md'
-      - '**/.*'
+      - '.*'
       - Pipfile*
   push:
     paths-ignore:
       - '**/*.cfg'
       - '**/*.md'
-      - '**/.*'
+      - '.*'
       - Pipfile*
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,13 @@ on:
     paths-ignore:
       - '**/*.cfg'
       - '**/*.md'
-      - '**/.*'
+      - '.*'
       - Pipfile*
   push:
     paths-ignore:
       - '**/*.cfg'
       - '**/*.md'
-      - '**/.*'
+      - '.*'
       - Pipfile*
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         args: ["-c", ".yamllint", "-s"]
 
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v25.1.3
+    rev: v25.4.0
     hooks:
       - id: ansible-lint
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,22 @@ check [`defaults/main.yml`](defaults/main.yml).
 
 ### Docker
 
-To test on Docker containers, run:
+Steps to test role on Docker containers.
 
-```shell
-ansible-playbook -i tests/inventory/docker-containers.yml tests/playbooks/docker-containers.yml
-```
+1. Install the current role by running the following commands in shell:
+
+    ```shell
+    ansible-galaxy install -r requirements.yml
+    jinja2 requirements-local.yml.j2 -D "pwd=$PWD" -o requirements-local.yml
+    ansible-galaxy install -r requirements-local.yml
+    ```
+
+2. Ensure Docker service (e.g. Docker Desktop) is running.
+3. Run playbook from `tests/`:
+
+    ```shell
+    ansible-playbook -i tests/inventory/docker-containers.yml tests/playbooks/docker-containers.yml
+    ```
 
 ### Molecule
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 # yamllint disable rule:line-length
 ---
+wine_become_method: ansible.builtin.su
 wine_install_recommends: false
 wine_install_winetricks: false
 wine_install_winetricks_dependencies:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -6,7 +6,7 @@
 
     - name: Install Python for Ansible
       become: "{{ (ansible_user_id is defined and ansible_user_id != 'root') or (lookup('env', 'UID') | int != 0) }}"
-      become_method: ansible.builtin.su
+      become_method: "{{ wine_become_method }}"
       ansible.builtin.raw: |
         command -v python3 || command -v python || (apt -y update && apt install -y python3-minimal)
       changed_when: false

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -2,6 +2,8 @@
 - name: Prepare hosts
   hosts: "all:!nixos*"
   gather_facts: false
+  vars:
+    wine_become_method: ansible.builtin.su
   tasks:
 
     - name: Install Python for Ansible

--- a/tasks/wine/wine-Alpine.yml
+++ b/tasks/wine/wine-Alpine.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensures Wine is present
   become: "{{ (ansible_user_id is defined and ansible_user_id != 'root') or (lookup('env', 'UID') | int != 0) }}"
-  become_method: ansible.builtin.su
+  become_method: "{{ wine_become_method }}"
   block:
 
     - name: Ensures Wine is present ({{ ansible_os_family }})

--- a/tasks/wine/wine-Darwin.yml
+++ b/tasks/wine/wine-Darwin.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensures Wine is present (Homebrew Cast)
   become: "{{ ansible_user_id is defined and ansible_user_id != 'root' }}"
-  become_method: ansible.builtin.sudo
+  become_method: "{{ wine_become_method }}"
   block:
     - name: Ensures Wine is present (Homebrew Cast)
       community.general.homebrew_cask:

--- a/tasks/wine/wine-Debian.yml
+++ b/tasks/wine/wine-Debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensures Wine repository is configured
   become: "{{ (ansible_user_id is defined and ansible_user_id != 'root') or (lookup('env', 'UID') | int != 0) }}"
-  become_method: ansible.builtin.su
+  become_method: "{{ wine_become_method }}"
   block:
     - name: Ensures lsb_release command is present
       ansible.builtin.package:

--- a/tasks/wine/wine-OtherLinux.yml
+++ b/tasks/wine/wine-OtherLinux.yml
@@ -6,7 +6,7 @@
 
 - name: Ensure Wine is installed (Nix)
   become: "{{ ansible_user_id != 'root' }}"
-  become_method: ansible.builtin.su
+  become_method: "{{ wine_become_method }}"
   block:
 
     - name: Check if Wine is already installed

--- a/tasks/winetricks/install-deps-Alpine.yml
+++ b/tasks/winetricks/install-deps-Alpine.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensures that dependencies are installed
   become: "{{ ansible_user_id != 'root' }}"
-  become_method: ansible.builtin.su
+  become_method: "{{ wine_become_method }}"
   block:
 
     - name: Install winetricks dependencies (Alpine)

--- a/tasks/winetricks/install-deps-Alpine.yml
+++ b/tasks/winetricks/install-deps-Alpine.yml
@@ -1,6 +1,7 @@
 ---
 - name: Ensures that dependencies are installed
   become: "{{ ansible_user_id != 'root' }}"
+  become_method: ansible.builtin.su
   block:
 
     - name: Install winetricks dependencies (Alpine)

--- a/tasks/winetricks/install-deps-Darwin.yml
+++ b/tasks/winetricks/install-deps-Darwin.yml
@@ -1,7 +1,6 @@
 ---
 - name: Ensure Winetricks dependencies via Homebrew
   become: "{{ ansible_user_id != 'root' }}"
-  become_method: ansible.builtin.su
   community.general.homebrew:
     name: "{{ item }}"
     state: present

--- a/tasks/winetricks/install-deps-Darwin.yml
+++ b/tasks/winetricks/install-deps-Darwin.yml
@@ -1,6 +1,7 @@
 ---
 - name: Ensure Winetricks dependencies via Homebrew
   become: "{{ ansible_user_id != 'root' }}"
+  become_method: ansible.builtin.su
   community.general.homebrew:
     name: "{{ item }}"
     state: present

--- a/tasks/winetricks/install-deps-Debian.yml
+++ b/tasks/winetricks/install-deps-Debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensure Winetricks dependencies are installed
   become: "{{ ansible_user_id != 'root' }}"
-  become_method: ansible.builtin.su
+  become_method: "{{ wine_become_method }}"
   ansible.builtin.apt:
     name: "{{ wine_install_winetricks_dependencies }}"
     state: present
@@ -11,7 +11,7 @@
 
 - name: Apt cleanup
   become: "{{ ansible_user_id != 'root' }}"
-  become_method: ansible.builtin.su
+  become_method: "{{ wine_become_method }}"
   when: wine_install_winetricks | bool
   block:
 

--- a/tasks/winetricks/install-deps-Debian.yml
+++ b/tasks/winetricks/install-deps-Debian.yml
@@ -1,6 +1,7 @@
 ---
 - name: Ensure Winetricks dependencies are installed
   become: "{{ ansible_user_id != 'root' }}"
+  become_method: ansible.builtin.su
   ansible.builtin.apt:
     name: "{{ wine_install_winetricks_dependencies }}"
     state: present
@@ -9,7 +10,8 @@
   when: wine_install_winetricks | bool
 
 - name: Apt cleanup
-  become: true
+  become: "{{ ansible_user_id != 'root' }}"
+  become_method: ansible.builtin.su
   when: wine_install_winetricks | bool
   block:
 

--- a/tasks/winetricks/install-deps-OtherLinux.yml
+++ b/tasks/winetricks/install-deps-OtherLinux.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensures that winetricks dependencies are installed
   become: "{{ ansible_user_id != 'root' }}"
-  become_method: ansible.builtin.su
+  become_method: "{{ wine_become_method }}"
   block:
 
     - name: Check if Nix store exists

--- a/tasks/winetricks/install-deps-OtherLinux.yml
+++ b/tasks/winetricks/install-deps-OtherLinux.yml
@@ -1,6 +1,7 @@
 ---
 - name: Ensures that winetricks dependencies are installed
   become: "{{ ansible_user_id != 'root' }}"
+  become_method: ansible.builtin.su
   block:
 
     - name: Check if Nix store exists

--- a/tasks/winetricks/winetricks-Alpine.yml
+++ b/tasks/winetricks/winetricks-Alpine.yml
@@ -1,6 +1,7 @@
 ---
 - name: Ensures winetricks is present ({{ ansible_os_family }})
   become: "{{ ansible_user_id != 'root' }}"
+  become_method: ansible.builtin.su
   block:
 
     - name: Ensures Winetricks is present (via URL)

--- a/tasks/winetricks/winetricks-Alpine.yml
+++ b/tasks/winetricks/winetricks-Alpine.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensures winetricks is present ({{ ansible_os_family }})
   become: "{{ ansible_user_id != 'root' }}"
-  become_method: ansible.builtin.su
+  become_method: "{{ wine_become_method }}"
   block:
 
     - name: Ensures Winetricks is present (via URL)

--- a/tasks/winetricks/winetricks-Debian.yml
+++ b/tasks/winetricks/winetricks-Debian.yml
@@ -7,7 +7,7 @@
 
 - name: Ensures Winetricks is installed ({{ ansible_os_family }})
   become: "{{ (ansible_user_id is defined and ansible_user_id != 'root') or (lookup('env', 'UID') | int != 0) }}"
-  become_method: ansible.builtin.su
+  become_method: "{{ wine_become_method }}"
   when: wine_install_winetricks | bool
   block:
 

--- a/tasks/winetricks/winetricks-Debian.yml
+++ b/tasks/winetricks/winetricks-Debian.yml
@@ -7,6 +7,7 @@
 
 - name: Ensures Winetricks is installed ({{ ansible_os_family }})
   become: "{{ (ansible_user_id is defined and ansible_user_id != 'root') or (lookup('env', 'UID') | int != 0) }}"
+  become_method: ansible.builtin.su
   when: wine_install_winetricks | bool
   block:
 

--- a/tasks/winetricks/winetricks-OtherLinux.yml
+++ b/tasks/winetricks/winetricks-OtherLinux.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensures Winetricks is installed ({{ ansible_os_family }})
   become: "{{ ansible_user_id != 'root' }}"
-
+  become_method: ansible.builtin.su
   block:
 
     - name: Check if winetricks is already installed

--- a/tasks/winetricks/winetricks-OtherLinux.yml
+++ b/tasks/winetricks/winetricks-OtherLinux.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensures Winetricks is installed ({{ ansible_os_family }})
   become: "{{ ansible_user_id != 'root' }}"
-  become_method: ansible.builtin.su
+  become_method: "{{ wine_become_method }}"
   block:
 
     - name: Check if winetricks is already installed

--- a/tasks/winetricks/winetricks.yml
+++ b/tasks/winetricks/winetricks.yml
@@ -1,6 +1,7 @@
 ---
 - name: Ensures winetricks and dependencies are present
   become: "{{ ansible_user_id != 'root' }}"
+  become_method: ansible.builtin.su
   when: wine_install_winetricks | bool
   block:
 

--- a/tasks/winetricks/winetricks.yml
+++ b/tasks/winetricks/winetricks.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensures winetricks and dependencies are present
   become: "{{ ansible_user_id != 'root' }}"
-  become_method: ansible.builtin.su
+  become_method: "{{ wine_become_method }}"
   when: wine_install_winetricks | bool
   block:
 

--- a/tests/playbooks/docker-containers.yml
+++ b/tests/playbooks/docker-containers.yml
@@ -13,6 +13,7 @@
       wine-on-ubuntu-latest: ubuntu:latest
       wine-on-ubuntu-noble: ubuntu:noble
     container_image: "{{ container_image_map[inventory_hostname] | default('ubuntu:latest') }}"
+    wine_become_method: ansible.builtin.su
     wine_install_winetricks: true
   pre_tasks:
     - name: Ensure container is started

--- a/tests/playbooks/docker-containers.yml
+++ b/tests/playbooks/docker-containers.yml
@@ -37,7 +37,7 @@
       ansible.builtin.raw: |
         test -e "{{ ansible_python_interpreter }}" || (apk update && apk add --no-cache python3 py3-pip)
       become: "{{ become_for_container }}"
-      become_method: ansible.builtin.su
+      become_method: "{{ wine_become_method }}"
       changed_when: false
       when: container_image is search("alpine")
 
@@ -45,7 +45,7 @@
       ansible.builtin.raw: |
         test -e "{{ ansible_python_interpreter }}" || (nix-env -iA nixpkgs.python3 nixpkgs.python3Packages.pip)
       become: "{{ become_for_container }}"
-      become_method: ansible.builtin.su
+      become_method: "{{ wine_become_method }}"
       changed_when: false
       when: container_image is search("nixos")
 
@@ -53,14 +53,14 @@
       ansible.builtin.raw: |
         test -e "{{ ansible_python_interpreter }}" || (apt-get update && apt-get install -y python3 python3-pip)
       become: "{{ become_for_container }}"
-      become_method: ansible.builtin.su
+      become_method: "{{ wine_become_method }}"
       changed_when: false
       when: container_image is search("ubuntu") or container_image is search("debian")
 
     - name: Gather facts
       ansible.builtin.setup:
       become: "{{ become_for_container }}"
-      become_method: ansible.builtin.su
+      become_method: "{{ wine_become_method }}"
 
     - name: Install Python packages for Ubuntu/Debian
       ansible.builtin.apt:
@@ -71,7 +71,7 @@
         state: present
         update_cache: true
       become: "{{ become_for_container }}"
-      become_method: ansible.builtin.su
+      become_method: "{{ wine_become_method }}"
       when: container_image is search("ubuntu") or container_image is search("debian")
 
 - name: Install ea31337.wine role on all containers

--- a/tests/playbooks/docker-containers.yml
+++ b/tests/playbooks/docker-containers.yml
@@ -13,6 +13,7 @@
       wine-on-ubuntu-latest: ubuntu:latest
       wine-on-ubuntu-noble: ubuntu:noble
     container_image: "{{ container_image_map[inventory_hostname] | default('ubuntu:latest') }}"
+    wine_install_winetricks: true
   pre_tasks:
     - name: Ensure container is started
       community.docker.docker_container:


### PR DESCRIPTION
## Summary by Sourcery

Update privilege escalation method to use 'ansible.builtin.su' across Winetricks-related tasks, enhance Docker testing instructions, and update CI and linting configurations.

Enhancements:
- Standardize privilege escalation with 'become_method: ansible.builtin.su' in Winetricks tasks for all supported platforms.

Build:
- Update ansible-lint pre-commit hook to version v25.4.0.

CI:
- Refine CI workflow path ignore patterns for improved triggering behavior.

Documentation:
- Expand and clarify Docker container testing instructions in the README.

Tests:
- Set 'wine_install_winetricks' to true in Docker test playbook for consistent test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable option to set the privilege escalation method for installation and setup tasks, allowing for greater flexibility across different environments.
  - Added a new default variable to control the privilege escalation method.
  - Enhanced playbook variables for more granular control over Winetricks installation in containerized environments.

- **Documentation**
  - Expanded and clarified the README instructions for testing the Ansible role with Docker containers, providing detailed step-by-step guidance.

- **Chores**
  - Updated the ansible-lint tool version in the pre-commit configuration.
  - Adjusted workflow triggers to refine which hidden files and directories are ignored during GitHub Actions runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->