### PR TITLE
Changed way fo clearing data before each of the scenario runs

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -21,6 +21,10 @@ on:
       - LICENSE
       - Pipfile*
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -38,22 +42,26 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: ${{ github.repository }}
-      - name: Clean up Docker resources before test
+      - name: Show disk usage before cache cleanup
         run: |
-          echo "=== Disk usage before cleanup ==="
+          echo "=== Disk usage before cache cleanup ==="
           df -h
-          docker system df
-          echo "=== Cleaning up Docker resources ==="
-          docker ps -aq | xargs -r docker stop || true
-          docker ps -aq | xargs -r docker rm -f || true
-          docker images -aq | xargs -r docker rmi -f || true
-          docker volume ls -q | xargs -r docker volume rm -f || true
-          docker network prune -f || true
-          docker system prune -af --volumes || true
-          echo "=== Disk usage after cleanup ==="
-          df -h
-          docker system df
+      - name: Free up disk space by removing unused tools
+        run: |
+          echo "=== Removing unused tools and caches ==="
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          sudo rm -rf /opt/hostedtoolcache/go || true
+          sudo rm -rf /opt/hostedtoolcache/Ruby || true
+          sudo rm -rf /opt/hostedtoolcache/PyPy || true
+          sudo rm -rf /opt/microsoft/msedge || true
+          sudo rm -rf /opt/az || true
+          sudo rm -rf /opt/google/chrome || true
         continue-on-error: true
+      - name: Show disk usage after cache cleanup
+        run: |
+          echo "=== Disk usage after cache cleanup ==="
+          df -h
       - uses: gofrolist/molecule-action@v2
         env:
           ANSIBLE_FORCE_COLOR: '1'
@@ -66,19 +74,6 @@ jobs:
           molecule_command: test
           molecule_options: ${{ runner.debug == '1' && '--verbose' || '' }}
           molecule_working_dir: ${{ github.repository }}
-      - if: always()
-        name: Clean up Docker resources after test
-        run: |
-          echo "=== Cleaning up Docker resources ==="
-          docker ps -aq | xargs -r docker stop || true
-          docker ps -aq | xargs -r docker rm -f || true
-          docker images -aq | xargs -r docker rmi -f || true
-          docker volume ls -q | xargs -r docker volume rm -f || true
-          docker network prune -f || true
-          docker system prune -af --volumes || true
-          echo "=== Final disk usage ==="
-          df -h
-          docker system df
         continue-on-error: true
       - if: always()
         name: Ensure report file permissions are correct

--- a/tasks/wine/wine-Debian.yml
+++ b/tasks/wine/wine-Debian.yml
@@ -66,6 +66,10 @@
         mode: "0644"
       when:
         - lsb_release_dist_id.stdout in ["Ubuntu"]
+    - name: Update Apt cache after adding Wine repositories
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 0
 
 - name: Ensures Wine is present
   become: >


### PR DESCRIPTION
## Summary by Sourcery

Adjust Molecule CI workflow to clear GitHub Actions cache and inspect disk usage before Docker cleanup, and simplify post-test Docker cleanup handling.

CI:
- Add steps to list and delete all GitHub Actions caches, with disk usage logging before and after cache cleanup.
- Run Docker cleanup and reporting only before Molecule tests instead of both before and after, while retaining error-tolerant behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow: added disk-usage reports before and after cache/tool cleanup, replaced broad Docker pruning with targeted removal of unused tools and cached tool homes, and removed the post-test Docker cleanup block.
  * System setup: ensure package cache is refreshed immediately after adding Wine repositories to improve subsequent package installation reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->