### PR TITLE
Cogni AI Agent support

### DIFF
--- a/.github/workflows/cogni-ai-agent.yml
+++ b/.github/workflows/cogni-ai-agent.yml
@@ -64,7 +64,7 @@ jobs:
           persist-credentials: false  # Prevents Duplicate header: "Authorization" error.
       # See: <https://github.com/Cogni-AI-OU/cogni-ai-agent-action>
       - name: Run Cogni AI Agent
-        uses: Cogni-AI-OU/cogni-ai-agent-action@main
+        uses: nseam/cogni-ai-agent-action@test/wine-support
         with:
           model: ${{ inputs.model }}
           opencode-api-key: ${{ secrets.OPENCODE_API_KEY }}  # <https://opencode.ai/auth>

--- a/.github/workflows/cogni-ai-agent.yml
+++ b/.github/workflows/cogni-ai-agent.yml
@@ -80,7 +80,7 @@ jobs:
         run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       # See: <https://github.com/Cogni-AI-OU/cogni-ai-agent-action>
       - name: Run Cogni AI Agent
-        uses: nseam/cogni-ai-agent-action@test/wine-support
+        uses: Cogni-AI-OU/cogni-ai-agent-action@main
         with:
           model: ${{ inputs.model }}
           opencode-api-key: ${{ secrets.OPENCODE_API_KEY }}  # <https://opencode.ai/auth>
@@ -143,10 +143,16 @@ jobs:
         run: python -m pip install --user pre-commit
       - name: Install dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
-        run: if [ -f .devcontainer/requirements.txt ]; then python -m pip install --user -r .devcontainer/requirements.txt; fi
+        run: |
+          if [ -f .devcontainer/requirements.txt ]; then
+            python -m pip install --user -r .devcontainer/requirements.txt
+          fi
+      - name: Set local bin path
+        run: echo "PYTHON_USER_SITE=$HOME/.local" >> "$GITHUB_ENV"
       - name: Share Python user site with agent
         uses: actions/upload-artifact@v4
         with:
           name: python-user-site
-          path: ~/.local
+          path: ${{ env.PYTHON_USER_SITE }}
           if-no-files-found: error
+          include-hidden-files: true


### PR DESCRIPTION
## Summary by Sourcery

Configure the Cogni AI agent workflow to share a cached Python user site between jobs, tighten shell command permissions, and allow the agent prompt to come from issue or PR comments.

CI:
- Make the Cogni AI agent job depend on the dependencies job and restore the cached Python user site before running the agent.
- Switch the dependencies job to cache the Python user site in the home directory, install tools with user-level pip when needed, and upload the site as an artifact for reuse.
- Restrict the Cogni AI agent bash command permissions and allow the agent prompt to fall back to the triggering comment body when available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline with improved dependency caching for faster builds.
  * Enhanced AI agent to accept prompts directly from issue comments.
  * Strengthened security controls on automated workflows with restricted command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->